### PR TITLE
boba fee fix

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -96,7 +96,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "input" => "#{transaction.input}",
       "contractAddress" => "#{transaction.created_contract_address_hash}",
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
-      "l2BobaFee" => "#{transaction.l2_boba_fee}",
+      "l2BobaFee" => "#{transaction.l2_boba_fee.value}",
       "gasUsed" => "#{transaction.gas_used}"
     }
   end
@@ -119,7 +119,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "input" => "#{transaction.input}",
       "contractAddress" => "#{transaction.created_contract_address_hash}",
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
-      "l2BobaFee" => "#{transaction.l2_boba_fee}",
+      "l2BobaFee" => "#{transaction.l2_boba_fee.value}",
       "gasUsed" => "#{transaction.gas_used}",
       "confirmations" => "#{transaction.confirmations}"
     }
@@ -163,7 +163,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "gasPrice" => to_string(token_transfer.transaction_gas_price.value),
       "gasUsed" => to_string(token_transfer.transaction_gas_used),
       "cumulativeGasUsed" => to_string(token_transfer.transaction_cumulative_gas_used),
-      "l2BobaFee" => "#{token_transfer.transaction_l2_boba_fee}",
+      "l2BobaFee" => to_string("#{token_transfer.transaction_l2_boba_fee.value}"),
       "input" => to_string(token_transfer.transaction_input),
       "confirmations" => to_string(token_transfer.confirmations)
     }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -163,7 +163,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "gasPrice" => to_string(token_transfer.transaction_gas_price.value),
       "gasUsed" => to_string(token_transfer.transaction_gas_used),
       "cumulativeGasUsed" => to_string(token_transfer.transaction_cumulative_gas_used),
-      "l2BobaFee" => to_string("#{token_transfer.transaction_l2_boba_fee.value}"),
+      "l2BobaFee" => to_string(token_transfer.transaction_l2_boba_fee.value),
       "input" => to_string(token_transfer.transaction_input),
       "confirmations" => to_string(token_transfer.confirmations)
     }


### PR DESCRIPTION
The API route was crashing:
```
curl -X GET "http://localhost:4000/api?module=account&action=txlist&address=0xd86D22c02E301BE7C35e3Ef20962f614cAf32B76&page=0&offset=0" -H "accept: application/json"
```

with the error:


`2022-05-31T17:13:54.978 application=block_scout_web request_id=FvQ_6WBSoMucXTARumMi [error] Error while calling RPC action"** (Plug.Conn.WrapperError) ** (Protocol.UndefinedError) protocol String.Chars not implemented for #Explorer.Chain.Wei<0> of type Explorer.Chain.Wei (a struct). This protocol is implemented for the following type(s): Explorer.Chain.Hash, Explorer.Chain.Address, Explorer.Chain.Data, Cldr.Unit, Postgrex.Query, Postgrex.Copy, Que.Job, FileInfo.Mime, ExJsonSchema.Validator.Error.Pattern, ExJsonSchema.Validator.Error.OneOf, ExJsonSchema.Validator.Error.AdditionalProperties, ExJsonSchema.Validator.Error.MinLength, ExJsonSchema.Validator.Error.AnyOf, ExJsonSchema.Validator.Error.Dependencies, ExJsonSchema.Validator.Error.Type, ExJsonSchema.Validator.Error.AllOf, ExJsonSchema.Validator.Error.MaxLength, ExJsonSchema.Validator.Error.MinItems, ExJsonSchema.Validator.Error.MultipleOf, ExJsonSchema.Validator.Error.MinProperties, ExJsonSchema.Validator.Error.Required, ExJsonSchema.Validator.Error.Minimum, ExJsonSchema.Validator.Error.MaxProperties, ExJsonSchema.Validator.Error.Not, ExJsonSchema.Validator.Error.Maximum, ExJsonSchema.Validator.Error.MaxItems, ExJsonSchema.Validator.Error.Enum, ExJsonSchema.Validator.Error.UniqueItems, ExJsonSchema.Validator.Error.Format, ExJsonSchema.Validator.Error.AdditionalItems, Floki.Selector, Floki.Selector.Combinator, Floki.Selector.PseudoClass, Floki.Selector.AttributeSelector, Floki.Selector.Functional, Decimal, BitString, DateTime, List, Date, Float, Atom, NaiveDateTime, Time, URI, Version.Requirement, Version, Integer\n    (elixir 1.11.4) lib/string/chars.ex:3: String.Chars.impl_for!/1\n    (elixir 1.11.4) lib/string/chars.ex:22: String.Chars.to_string/1\n    (block_scout_web 0.0.1) lib/block_scout_web/views/api/rpc/address_view.ex:122: BlockScoutWeb.API.RPC.AddressView.prepare_transaction/1\n    (elixir 1.11.4) lib/enum.ex:1411: Enum.\"-map/2-lists^map/1-0-\"/2\n    (block_scout_web 0.0.1) lib/block_scout_web/views/api/rpc/address_view.ex:31: BlockScoutWeb.API.RPC.AddressView.render/2\n    (phoenix 1.5.6) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3\n    (phoenix 1.5.6) lib/phoenix/controller.ex:776: Phoenix.Controller.render_and_send/4\n    (block_scout_web 0.0.1) lib/block_scout_web/controllers/api/rpc/address_controller.ex:1: BlockScoutWeb.API.RPC.AddressController.action/2\n"
`